### PR TITLE
Fix resource paths for PyInstaller

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,20 +13,7 @@ from composer_list_page     import ComposerListPage
 from step_prepare_step1     import StepPrepareStep1
 
 from util_json import load_json_safe
-
-
-# ───────────────────────── util: путь к ресурсам ──────────────────────────
-def rsrc(rel_path: str) -> str:
-    """
-    Возвращает абсолютный путь к ресурсу:
-    • при запуске из исходников — рядом с .py  
-    • в упакованном .app / .exe — внутри каталога Resources
-    """
-    if getattr(sys, 'frozen', False):                # PyInstaller
-        base = sys._MEIPASS                         # type: ignore
-    else:
-        base = os.path.abspath(os.path.dirname(__file__))
-    return os.path.join(base, rel_path)
+from util_path import rsrc
 
 
 CONFIG_FILE = "config.json"                         # имя не меняем — используем rsrc()

--- a/step1_create_structure.py
+++ b/step1_create_structure.py
@@ -9,6 +9,7 @@ from PyQt6.QtMultimedia import QSoundEffect
 from PyQt6.QtCore import QUrl
 
 from util_json import load_json_safe
+from util_path import rsrc
 
 CONFIG_FILE  = "config.json"
 SESSION_FILE = "session.json"
@@ -95,8 +96,8 @@ class Step1CreateStructure(QWidget):
 
     # ───────── настройки / альбомы ─────────
     def load_settings(self):
-        cfg_path = CONFIG_FILE                         # либо rsrc(CONFIG_FILE)
-        self.paths = load_json_safe(cfg_path, {})      # ← одно слово
+        cfg_path = rsrc(CONFIG_FILE)
+        self.paths = load_json_safe(cfg_path, {})
 
     def load_albums(self):
         self.album_list.clear()
@@ -181,7 +182,7 @@ class Step1CreateStructure(QWidget):
         self.next_button.setStyleSheet("background-color: #388E3C; color: white; font-weight: bold;")
         # проигрываем звук
         self.next_step_sound = QSoundEffect()
-        self.next_step_sound.setSource(QUrl.fromLocalFile("notify.wav"))
+        self.next_step_sound.setSource(QUrl.fromLocalFile(rsrc("notify.wav")))
         self.next_step_sound.setVolume(0.5)
         self.next_step_sound.play()
 

--- a/step2_process_stems.py
+++ b/step2_process_stems.py
@@ -14,6 +14,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui  import QCursor
 from PyQt6.QtMultimedia import QSoundEffect
 from PyQt6.QtCore import QUrl
+from util_path import rsrc
 
 SESSION_FILE     = "session.json"
 IGNORE_KEYWORDS  = ["mix", "full mix", "unmastered", "mastered", "master", "bpm"]
@@ -214,7 +215,7 @@ class Step2ProcessStems(QWidget):
         self.next_btn.setEnabled(True)
         self.next_btn.setStyleSheet("background-color: #388E3C; color: white; font-weight: bold;")
         self.next_step_sound = QSoundEffect()
-        self.next_step_sound.setSource(QUrl.fromLocalFile("notify.wav"))
+        self.next_step_sound.setSource(QUrl.fromLocalFile(rsrc("notify.wav")))
         self.next_step_sound.setVolume(0.5)
         self.next_step_sound.play()
 

--- a/step3_composer_match.py
+++ b/step3_composer_match.py
@@ -9,6 +9,7 @@ from PyQt6.QtGui  import QCursor
 from add_composer_dialog import AddComposerDialog
 from PyQt6.QtMultimedia import QSoundEffect
 from PyQt6.QtCore import QUrl
+from util_path import rsrc
 
 DATABASES_FOLDER     = "_DATABASES"
 COMPOSER_DB_FILENAME = "composer_database.json"
@@ -138,7 +139,7 @@ class Step3ComposerMatch(QWidget):
             "background-color:#388E3C; color:white; font-weight:bold;")
 
         self.next_step_sound = QSoundEffect()
-        self.next_step_sound.setSource(QUrl.fromLocalFile("notify.wav"))
+        self.next_step_sound.setSource(QUrl.fromLocalFile(rsrc("notify.wav")))
         self.next_step_sound.setVolume(0.5)
         self.next_step_sound.play()
 

--- a/step4_add_cover.py
+++ b/step4_add_cover.py
@@ -7,6 +7,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt
 from PyQt6.QtMultimedia import QSoundEffect
 from PyQt6.QtCore import QUrl
+from util_path import rsrc
 
 SESSION_FILE = "session.json"
 CONFIG_FILE  = "config.json"
@@ -86,9 +87,9 @@ class Step4AddCover(QWidget):
             self.log("❌ Недостаточно данных в session.json."); return
 
         # 2) config.json → папка обложек
-        if not os.path.exists(CONFIG_FILE):
+        if not os.path.exists(rsrc(CONFIG_FILE)):
             self._err("Ошибка", "Нет config.json!"); return
-        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        with open(rsrc(CONFIG_FILE), "r", encoding="utf-8") as f:
             covers_root = json.load(f).get("_ALL ALBUMS COVERS", "")
         if not covers_root or not os.path.isdir(covers_root):
             self._err("Ошибка", f"Папка обложек не найдена:\n{covers_root}"); return
@@ -120,7 +121,7 @@ class Step4AddCover(QWidget):
         self.next_btn.setEnabled(True)
         self.next_btn.setStyleSheet("background-color: #388E3C; color: white; font-weight: bold;")
         self.next_step_sound = QSoundEffect()
-        self.next_step_sound.setSource(QUrl.fromLocalFile("notify.wav"))
+        self.next_step_sound.setSource(QUrl.fromLocalFile(rsrc("notify.wav")))
         self.next_step_sound.setVolume(0.5)
         self.next_step_sound.play()
 

--- a/step5_generate_metadata.py
+++ b/step5_generate_metadata.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore        import Qt, QDate, QUrl
 from PyQt6.QtGui         import QDesktopServices
 from PyQt6.QtMultimedia  import QSoundEffect
+from util_path import rsrc
 
 
 SESSION_FILE        = "session.json"
@@ -99,23 +100,23 @@ class Step5GenerateMetadata(QWidget):
             self.ses = json.load(f)
 
         # config
-        if not os.path.exists(CONFIG_FILE):
+        if not os.path.exists(rsrc(CONFIG_FILE)):
             self._err("Нет config.json."); return
-        with open(CONFIG_FILE,"r",encoding="utf-8") as f:
+        with open(rsrc(CONFIG_FILE),"r",encoding="utf-8") as f:
             cfg = json.load(f)
         self.meta_dir = cfg.get("_ALL ALBUMS METADATA","")
         if not os.path.isdir(self.meta_dir):
             self._err(f"Папка METADATA не найдена:\n{self.meta_dir}"); return
 
         # базы
-        with open(COMPOSER_DB_FILE,"r",encoding="utf-8") as f:
+        with open(rsrc(COMPOSER_DB_FILE),"r",encoding="utf-8") as f:
             db = json.load(f)
         self.composers  = db.get("composers",{})
         self.publishers = db.get("publishers",{})
 
         self.isrc_db = {}
-        if os.path.exists(ISRC_DB_FILE):
-            with open(ISRC_DB_FILE,"r",encoding="utf-8") as f:
+        if os.path.exists(rsrc(ISRC_DB_FILE)):
+            with open(rsrc(ISRC_DB_FILE),"r",encoding="utf-8") as f:
                 self.isrc_db = json.load(f)
         self.last_isrc = self._find_last_isrc()
 
@@ -225,7 +226,7 @@ class Step5GenerateMetadata(QWidget):
             rows.append([rd.get(c,"") for c in cols])
 
         # записываем isrc-базу
-        with open(ISRC_DB_FILE,"w",encoding="utf-8") as f:
+        with open(rsrc(ISRC_DB_FILE),"w",encoding="utf-8") as f:
             json.dump(self.isrc_db,f,indent=4)
 
         # xlsx-файл альбома
@@ -291,7 +292,7 @@ class Step5GenerateMetadata(QWidget):
         self.btn_next.setEnabled(True)
         self.btn_next.setStyleSheet("background:#388E3C;color:white;font-weight:bold;")
 
-        snd = QSoundEffect(self); snd.setSource(QUrl.fromLocalFile("notify.wav"))
+        snd = QSoundEffect(self); snd.setSource(QUrl.fromLocalFile(rsrc("notify.wav")))
         snd.setVolume(0.5); snd.play()
 
         self._info("Синхронизация выполнена (бэкап создан).")

--- a/step6_prepare_harvest.py
+++ b/step6_prepare_harvest.py
@@ -9,6 +9,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore         import Qt, QUrl
 from PyQt6.QtMultimedia   import QSoundEffect
 from PyQt6.QtGui          import QDesktopServices
+from util_path import rsrc
 
 
 SESSION_FILE = "session.json"
@@ -85,9 +86,9 @@ class Step6PrepareHarvest(QWidget):
         self.log_out.append(text)
 
     def load_config(self):
-        if not os.path.exists(CONFIG_FILE):
+        if not os.path.exists(rsrc(CONFIG_FILE)):
             self.show_error("Ошибка", "config.json не найден. Повторите предыдущие шаги."); return
-        with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        with open(rsrc(CONFIG_FILE), "r", encoding="utf-8") as f:
             self.config = json.load(f)
 
     def _err(self, title: str, msg: str):
@@ -225,7 +226,7 @@ class Step6PrepareHarvest(QWidget):
             "background-color:#388E3C; color:white; font-weight:bold;")
         # пинг
         self._snd = QSoundEffect()
-        self._snd.setSource(QUrl.fromLocalFile("notify.wav"))
+        self._snd.setSource(QUrl.fromLocalFile(rsrc("notify.wav")))
         self._snd.setVolume(0.5)
         self._snd.play()
 

--- a/step_finals.py
+++ b/step_finals.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import (
 )
 from PyQt6.QtCore import Qt, QUrl
 from PyQt6.QtMultimedia import QSoundEffect
+from util_path import rsrc
 
 
 class StepFinals(QWidget):
@@ -54,7 +55,7 @@ class StepFinals(QWidget):
 
         # ── звук ──
         self.sound = QSoundEffect(self)
-        self.sound.setSource(QUrl.fromLocalFile("bruh.wav"))  # WAV/OGG файл
+        self.sound.setSource(QUrl.fromLocalFile(rsrc("bruh.wav")))  # WAV/OGG файл
         self.sound.setVolume(0.5)
         self.sound.play()
 

--- a/util_path.py
+++ b/util_path.py
@@ -1,0 +1,10 @@
+import os, sys
+
+def rsrc(rel_path: str) -> str:
+    """Return absolute path to a resource.
+    Works for development and PyInstaller bundles."""
+    if getattr(sys, 'frozen', False):
+        base = sys._MEIPASS  # type: ignore
+    else:
+        base = os.path.abspath(os.path.dirname(__file__))
+    return os.path.join(base, rel_path)


### PR DESCRIPTION
## Summary
- centralize resource path handling in new `util_path.py`
- import and use `rsrc()` across modules for packaged builds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f4980d5c4832c86f05af8da87a760